### PR TITLE
Save fields belonging to the form

### DIFF
--- a/app/controllers/rebate_forms_controller.rb
+++ b/app/controllers/rebate_forms_controller.rb
@@ -33,6 +33,8 @@ class RebateFormsController < ApiController
   # On validation errors, render correct error JSON.
   def create
     rebate_form, success = jsonapi_create.to_a
+    fields = params[:_jsonapi][:data][:attributes][:fields].to_json
+    rebate_form.update(fields: fields)
 
     if success
       render_jsonapi(rebate_form, scope: false)
@@ -46,6 +48,8 @@ class RebateFormsController < ApiController
   # On validation errors, render correct error JSON.
   def update
     rebate_form, success = jsonapi_update.to_a
+    fields = params[:_jsonapi][:data][:attributes][:fields].to_json
+    rebate_form.update(fields: fields)
 
     if success
       render_jsonapi(rebate_form, scope: false)

--- a/app/serializers/serializable_rebate_form.rb
+++ b/app/serializers/serializable_rebate_form.rb
@@ -17,4 +17,5 @@ class SerializableRebateForm < JSONAPI::Serializable::Resource
   # end
   attribute :valuation_id
   attribute :token
+  attribute :fields
 end

--- a/db/migrate/20180405042043_add_fields_to_rebate_form.rb
+++ b/db/migrate/20180405042043_add_fields_to_rebate_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddFieldsToRebateForm < ActiveRecord::Migration[5.1]
+  def change
+    change_table :rebate_forms do |t|
+      t.json :fields
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403020256) do
+ActiveRecord::Schema.define(version: 20180405042043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "rebate_forms", force: :cascade do |t|
     t.string "valuation_id"
@@ -21,6 +22,7 @@ ActiveRecord::Schema.define(version: 20180403020256) do
     t.json "payload"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "fields"
   end
 
   create_table "signature_types", force: :cascade do |t|

--- a/spec/factories/rebate_forms.rb
+++ b/spec/factories/rebate_forms.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :rebate_form do
     valuation_id '123'
     # token <-- auto generated. Don't set in factory
+    fields '{"name":"Fred","relationship":"complicated"}'
   end
 
   factory :signed_form, parent: :rebate_form do

--- a/spec/payloads/rebate_form.rb
+++ b/spec/payloads/rebate_form.rb
@@ -32,4 +32,5 @@
 JsonapiSpecHelpers::Payload.register(:rebate_form) do
   key(:valuation_id, String)
   key(:token, String)
+  key(:fields, String)
 end


### PR DESCRIPTION
# What has changed and why?
The fields on the form can be saved against the RebateForm model
This is schemaless - you can make up your own fields.

# How to test this change
Send a request body like his:


https://documenter.getpostman.com/collection/view/3560032-e1f3735b-15ab-469a-0f5b-877de1b98b07#3d9ada3f-cf96-ea3f-deb4-928c2ccfc8a4

POST {{server}}/api/v1/rebate_forms
```
{
  "data": {
    "type": "rebate-forms",
    "attributes": {
      "valuation_id": "abc",
      "fields": {
        "name": "Fred",
        "relationship": "complicated"
      }
    }
  }
}
```


The return will include the fields

You can also retrieve it like this:
GET {{server}}/api/v1/rebate_forms/{{token}}



- [x] has automated tests
- [ ] at least one a reviewer ran the code
- [x] updated API docs

closes #5