### PR TITLE
App.json for heroku config

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,17 @@
+{
+  "name": "pancake-backend",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate db:seed"
+  },
+  "env": {
+    "COUNCIL_EMAIL": {
+      "required": true
+    }
+  },
+  "formation": {
+  },
+  "addons": [ "sendgrid"],
+  "buildpacks": [
+
+  ]
+}


### PR DESCRIPTION
# What has changed and why?
An app.json file tells heroku what is needed to deploy an app
Adding this config means we can deploy an instance of the app on every pull request -- someone without a ruby dev environment can then test it when no dev is available for peer review.
