### PR TITLE
Go to rebate forms after sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,7 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  def after_sign_in_path_for(resource)
+    admin_rebate_forms_path
+  end
 end


### PR DESCRIPTION
# What has changed and why?

Devise redirects to / after login -- which means we end up on the app

this instead will send them to the index of rebate forms.

# How to test this change

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] updated API docs