### PR TITLE
Copy changes

### DIFF
--- a/app/views/rebate_forms_mailer/applicant_mail.html.haml
+++ b/app/views/rebate_forms_mailer/applicant_mail.html.haml
@@ -16,7 +16,7 @@
       Go to the Tauranga City Council at
       91 Willow Street, Tauranga.
     %li
-      Proof of income may be requested, especially for those with income sources other than superannuation or work and income benefits.
+      Proof of income may be requested for those with income sources other than superannuation or work and income benefits.
     %li
       If you are self-employed, you must supply evidence with your application.
     %li

--- a/app/views/rebate_forms_mailer/council_mail.html.haml
+++ b/app/views/rebate_forms_mailer/council_mail.html.haml
@@ -1,6 +1,7 @@
-Council email copy goes in here
+A new rebate application has been sent to you.
 
 %p= @rebate_form.valuation_id
 %p= @rebate_form.fields['address']
+%p= @rebate_form.fields['full_name']
 
 %p= link_to 'Sign this', @rebate_form.signing_url

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -1,1 +1,1 @@
-%p Welcome to pancake
+%p Welcome to Pancake

--- a/spec/models/rebate_form_spec.rb
+++ b/spec/models/rebate_form_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe RebateForm, type: :model do
     let(:form) { FactoryBot.create :rebate_form, property: property, valuation_id: valuation_id, fields: fields }
     let(:fields) { { "income": 39_900.00, "dependants": 1, "full_name": 'Edith' } }
     before { form.calc_rebate_amount! }
-    it { expect(form.rebate).to eq 370.42 }
+    it { expect(form.rebate).to eq 370.67 }
   end
 end


### PR DESCRIPTION
# What has changed and why?
- [ ] Removed the word 'especially' from 'Proof of income may be requested for those with income sources other than superannuation or work and income benefits.
- [ ] Changed the council email to say 'A new rebate application has been sent to you.' and attempted to add applicant name to council email.
- [ ] Capitalised Pancake on 'Welcome to pancake'


# How to test this change

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] updated API docs