### PR TITLE
improve spec for rebate form helper

### DIFF
--- a/app/helpers/rebate_forms_helper.rb
+++ b/app/helpers/rebate_forms_helper.rb
@@ -21,8 +21,8 @@ module RebateFormsHelper
 
   def rebate_form_lived_year?(rebate_form)
     field_name = 'lived_here_before_july_' + (rebate_form.rating_year.to_i - 1).to_s
-    if rebate_form[field_name].present?
-      rebate_form.fields[field_name].capitalize
+    if rebate_form.fields[field_name].present?
+      rebate_form.fields[field_name].to_s.capitalize
     else
       'No answer'
     end

--- a/app/helpers/rebate_forms_helper.rb
+++ b/app/helpers/rebate_forms_helper.rb
@@ -21,8 +21,8 @@ module RebateFormsHelper
 
   def rebate_form_lived_year?(rebate_form)
     field_name = 'lived_here_before_july_' + (rebate_form.rating_year.to_i - 1).to_s
-    if rebate_form.fields[field_name].present?
-      rebate_form.fields[field_name].to_s.capitalize
+    if rebate_form.lived_here.present?
+      rebate_form.lived_here.to_s.capitalize
     else
       'No answer'
     end

--- a/app/helpers/rebate_forms_helper.rb
+++ b/app/helpers/rebate_forms_helper.rb
@@ -20,7 +20,6 @@ module RebateFormsHelper
   end
 
   def rebate_form_lived_year?(rebate_form)
-    field_name = 'lived_here_before_july_' + (rebate_form.rating_year.to_i - 1).to_s
     if rebate_form.lived_here.present?
       rebate_form.lived_here.to_s.capitalize
     else

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -54,8 +54,8 @@ class RebateForm < ApplicationRecord
   end
 
   def lived_here
-    fields.each do |key, value|
-      return fields[key] if key.start_with?('lived_here_before_july_')
+    fields.each do |key, _value|
+      return value if key.start_with?('lived_here_before_july_')
     end
     nil
   end

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -14,6 +14,7 @@ class RebateForm < ApplicationRecord
   validates :valuation_id, presence: true
   validates :token, presence: true
   validates :rebate, presence: true
+  validates :property, presence: true
 
   validate :required_fields_present
   validate :same_council

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -53,6 +53,13 @@ class RebateForm < ApplicationRecord
     fields['income']
   end
 
+  def lived_here
+    fields.each do |key, value|
+      return fields[key] if key.start_with?('lived_here_before_july_')
+    end
+    nil
+  end
+
   def applicant_signature
     signatures.applicant.first
   end

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -54,7 +54,7 @@ class RebateForm < ApplicationRecord
   end
 
   def lived_here
-    fields.each do |key, _value|
+    fields.each do |key, value|
       return value if key.start_with?('lived_here_before_july_')
     end
     nil

--- a/spec/factories/rebate_forms.rb
+++ b/spec/factories/rebate_forms.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       end
     end
     # token <-- auto generated. Don't set in factory
-    fields { { "full_name": 'Fred', "income": 0, dependants: 0 } }
+    fields { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_2018": 'yes' } }
     completed { false }
     rebate { 555.12 }
     batch { nil }

--- a/spec/factories/rebate_forms.rb
+++ b/spec/factories/rebate_forms.rb
@@ -3,17 +3,20 @@
 FactoryBot.define do
   factory :rebate_form do
     valuation_id { Faker::Vehicle.vin }
-    property do
-      unless Property.find_by(valuation_id: valuation_id)
-        FactoryBot.create(:property_with_rates,
-                          valuation_id: valuation_id)
-      end
-    end
+    property { Property.find_by(valuation_id: valuation_id) }
     # token <-- auto generated. Don't set in factory
-    fields { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_#{rating_year.to_i - 1}": 'yes' } }
+    fields { { "full_name": 'Fred', "income": 0, dependants: 0 } }
     completed { false }
     rebate { 555.12 }
     batch { nil }
+
+    before(:create) do |rebate_form|
+      unless Property.find_by(valuation_id: rebate_form.valuation_id)
+        FactoryBot.create(:property_with_rates,
+                          rating_year: ENV['YEAR'],
+                          valuation_id: rebate_form.valuation_id)
+      end
+    end
   end
 
   factory :signed_form, parent: :rebate_form do

--- a/spec/factories/rebate_forms.rb
+++ b/spec/factories/rebate_forms.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
       end
     end
     # token <-- auto generated. Don't set in factory
-    fields { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_2018": 'yes' } }
+    fields { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_#{rating_year.to_i - 1}": 'yes' } }
     completed { false }
     rebate { 555.12 }
     batch { nil }

--- a/spec/helpers/rebate_forms_helper_spec.rb
+++ b/spec/helpers/rebate_forms_helper_spec.rb
@@ -22,7 +22,20 @@ RSpec.describe RebateFormsHelper, type: :helper do
   end
 
   describe 'rebate_form_lived_year?(rebate_form)' do
-    it { expect(rebate_form_lived_year?(rebate_form)).to eq 'Yes' }
+    let(:rebate_form) { FactoryBot.create :rebate_form, fields: fields }
+
+    describe 'yes' do
+      let(:fields) { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_2019": 'yes' } }
+      it { expect(rebate_form_lived_year?(rebate_form)).to eq 'Yes' }
+    end
+    describe 'no' do
+      let(:fields) { { "full_name": 'Fred', "income": 0, dependants: 0, "lived_here_before_july_2019": 'no' } }
+      it { expect(rebate_form_lived_year?(rebate_form)).to eq 'No' }
+    end
+    describe 'not answered' do
+      let(:fields) { { "full_name": 'Fred', "income": 0, dependants: 0 } }
+      it { expect(rebate_form_lived_year?(rebate_form)).to eq 'No answer' }
+    end
   end
 
   describe 'rebate_form_year_header(rebate_form)' do

--- a/spec/helpers/rebate_forms_helper_spec.rb
+++ b/spec/helpers/rebate_forms_helper_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RebateFormsHelper, type: :helper do
   end
 
   describe 'rebate_form_lived_year?(rebate_form)' do
-    it { expect(rebate_form_lived_year?(rebate_form)).to eq 'No answer' }
+    it { expect(rebate_form_lived_year?(rebate_form)).to eq 'Yes' }
   end
 
   describe 'rebate_form_year_header(rebate_form)' do


### PR DESCRIPTION
# What has changed and why?

fixed call to field

# How to test this change

PDF should no longer show 'No Answer' if an answer was supplied for:
`lived_here_before_july_2018` field

- [x] has automated tests
- [x] at least one a reviewer ran the code
- [ ] updated API docs