### PR TITLE
added condition to hide suburb if it inclues RT.VAL.AREAUNIT

### DIFF
--- a/app/views/admin/rebate_forms/_artefact.haml
+++ b/app/views/admin/rebate_forms/_artefact.haml
@@ -31,7 +31,7 @@
             %p
               = rebate_form.property.location
               %br/
-              - if !rebate_form.property.suburb.to_s.include?('RT.VAL.AREAUNIT')
+              - unless rebate_form.property.suburb.to_s.include?('RT.VAL.AREAUNIT')
                 = rebate_form.property.suburb
                 %br/
               = rebate_form.property.town_city


### PR DESCRIPTION
closes #227

# What has changed and why?

hide suburb if it includes RT.VAL.AREAUNIT
# How to test this change

- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] updated API docs

closes #299