### PR TITLE
Use different email template for Tauranga

### DIFF
--- a/app/mailers/rebate_forms_mailer.rb
+++ b/app/mailers/rebate_forms_mailer.rb
@@ -4,13 +4,15 @@ class RebateFormsMailer < ApplicationMailer
   def council_mail
     @rebate_form = params[:rebate_form]
     council_mail = @rebate_form.council.email
-    subject = @rebate_form.fields['what_is_your_address']
+    subject = "Rates rebate application for #{@rebate_form.property.location}"
     mail(to: council_mail, subject: subject)
   end
 
   def applicant_mail
     @rebate_form = params[:rebate_form]
-    applicant_email = @rebate_form.fields['email']
-    mail(to: applicant_email, subject: 'New Rates Rebate application')
+    @council = @rebate_form.council
+    applicant_email = @rebate_form.email
+    subject = 'Your Rates Rebate application'
+    mail(to: applicant_email, subject: subject)
   end
 end

--- a/app/models/rebate_form.rb
+++ b/app/models/rebate_form.rb
@@ -43,6 +43,10 @@ class RebateForm < ApplicationRecord
     fields['full_name']
   end
 
+  def email
+    fields['email']
+  end
+
   def dependants
     fields['dependants']
   end

--- a/app/views/rebate_forms_mailer/_default.haml
+++ b/app/views/rebate_forms_mailer/_default.haml
@@ -3,7 +3,7 @@
   = @rebate_form.full_name
 
 %p
-  Your application for a rates rebate for the 1 July #{@rebate_form.rating_year.to_i -1} – 30 June #{@rebate_form.rating_year} rates
+  Your application for a rates rebate for the 1 July #{@rebate_form.rating_year.to_i - 1} – 30 June #{@rebate_form.rating_year} rates
   year has been sent to the #{@council.name} City Council.
 
 %p
@@ -17,8 +17,8 @@
     %li If you are self-employed, you must supply income evidence with your application.
 
 %p
-  Please note: you can only apply for a rebate for the #{@rebate_form.rating_year.to_i -1}/#{@rebate_form.rating_year} rates year between
-  1 July #{@rebate_form.rating_year.to_i -1} – 30 June #{@rebate_form.rating_year}".
+  Please note: you can only apply for a rebate for the #{@rebate_form.rating_year.to_i - 1}/#{@rebate_form.rating_year} rates year between
+  1 July #{@rebate_form.rating_year.to_i - 1} – 30 June #{@rebate_form.rating_year}".
 
 %p
   Make sure you complete your application by getting your signature witnessed at the council

--- a/app/views/rebate_forms_mailer/_default.haml
+++ b/app/views/rebate_forms_mailer/_default.haml
@@ -3,7 +3,7 @@
   = @rebate_form.full_name
 
 %p
-  Your application for a rates rebate for the 1 July 2018 – 30 June 2019 rates
+  Your application for a rates rebate for the 1 July #{@rebate_form.rating_year.to_i -1} – 30 June #{@rebate_form.rating_year} rates
   year has been sent to the #{@council.name} City Council.
 
 %p
@@ -17,8 +17,8 @@
     %li If you are self-employed, you must supply income evidence with your application.
 
 %p
-  Please note: you can only apply for a rebate for the 2018/2019 rates year between
-  1 July 2018 – 30 June 2019.
+  Please note: you can only apply for a rebate for the #{@rebate_form.rating_year.to_i -1}/#{@rebate_form.rating_year} rates year between
+  1 July #{@rebate_form.rating_year.to_i -1} – 30 June #{@rebate_form.rating_year}".
 
 %p
   Make sure you complete your application by getting your signature witnessed at the council

--- a/app/views/rebate_forms_mailer/_default.haml
+++ b/app/views/rebate_forms_mailer/_default.haml
@@ -20,4 +20,8 @@
   Please note: you can only apply for a rebate for the 2018/2019 rates year between
   1 July 2018 – 30 June 2019.
 
+%p
+  Make sure you complete your application by getting your signature witnessed at the council
+  offices at your earliest convenience
+
 %p Once your application is completed, your total rebate will be applied to your rates account.

--- a/app/views/rebate_forms_mailer/_default.haml
+++ b/app/views/rebate_forms_mailer/_default.haml
@@ -1,0 +1,23 @@
+%p
+  Hi
+  = @rebate_form.full_name
+
+%p
+  Your application for a rates rebate for the 1 July 2018 – 30 June 2019 rates
+  year has been sent to the #{@council.name} City Council.
+
+%p
+  %b What you need to do now
+
+%p
+  %ul
+    %li Go to the a council service centre
+    %li Tell the Service Centre staff you're there to sign your rates rebate application.
+    %li Evidence of income helps to ensure you receive the correct rebate promptly.
+    %li If you are self-employed, you must supply income evidence with your application.
+
+%p
+  Please note: you can only apply for a rebate for the 2018/2019 rates year between
+  1 July 2018 – 30 June 2019.
+
+%p Once your application is completed, your total rebate will be applied to your rates account.

--- a/app/views/rebate_forms_mailer/_tcc.html.haml
+++ b/app/views/rebate_forms_mailer/_tcc.html.haml
@@ -1,0 +1,35 @@
+
+%p
+  Hi
+  = @rebate_form.fields['full_name']
+
+%p
+  Your application for a rates rebate for the 1 July 2018 – 30 June 2019 rates
+  year has been sent to the Tauranga City Council.
+
+%p
+  %b What you need to do now
+
+%p
+  %ul
+    %li Go to the Tauranga City Council at 91 Willow Street, Tauranga.
+    %li Evidence of income helps to ensure you receive the correct rebate promptly.
+    %li If you are self-employed, you must supply income evidence with your application.
+    %li Tell the Service Centre staff you're there to sign your rates rebate application.
+
+%p
+  %strong
+    Make sure you complete your application by getting your signature witnessed at council
+    offices as soon as you can, as online applications are only open until 31 August 2018.
+    If you do not complete the signature on your application before this date, you will need
+    to complete a paper application form.
+%p
+  Please note: you can only apply for a rebate for the 2018/2019 rates year between
+  1 July 2018 – 30 June 2019.
+
+%p Once your application is completed, your total rebate will be applied to your rates account.
+
+%p
+  %strong
+    If you have any issues, call Tauranga City Council
+    %a{ href: "tel:075777000" } 07 5777 000

--- a/app/views/rebate_forms_mailer/_tcc.html.haml
+++ b/app/views/rebate_forms_mailer/_tcc.html.haml
@@ -4,7 +4,7 @@
   = @rebate_form.fields['full_name']
 
 %p
-  Your application for a rates rebate for the 1 July 2018 – 30 June 2019 rates
+  Your application for a rates rebate for the 1 July #{@rebate_form.rating_year.to_i - 1} – 30 June #{@rebate_form.rating_year} rates
   year has been sent to the Tauranga City Council.
 
 %p
@@ -22,8 +22,8 @@
     Make sure you complete your application by getting your signature witnessed at the council
     offices at your earliest convenience
 %p
-  Please note: you can only apply for a rebate for the 2018/2019 rates year between
-  1 July 2018 – 30 June 2019.
+  Please note: you can only apply for a rebate for the #{@rebate_form.rating_year.to_i - 1}/#{@rebate_form.rating_year} rates year between
+  1 July #{@rebate_form.rating_year.to_i - 1} – 30 June #{@rebate_form.rating_year}.
 
 %p Once your application is completed, your total rebate will be applied to your rates account.
 

--- a/app/views/rebate_forms_mailer/_tcc.html.haml
+++ b/app/views/rebate_forms_mailer/_tcc.html.haml
@@ -19,10 +19,8 @@
 
 %p
   %strong
-    Make sure you complete your application by getting your signature witnessed at council
-    offices as soon as you can, as online applications are only open until 31 August 2018.
-    If you do not complete the signature on your application before this date, you will need
-    to complete a paper application form.
+    Make sure you complete your application by getting your signature witnessed at the council
+    offices at your earliest convenience
 %p
   Please note: you can only apply for a rebate for the 2018/2019 rates year between
   1 July 2018 – 30 June 2019.

--- a/app/views/rebate_forms_mailer/applicant_mail.html.haml
+++ b/app/views/rebate_forms_mailer/applicant_mail.html.haml
@@ -1,35 +1,6 @@
 
-%p
-  Hi
-  = @rebate_form.fields['full_name']
+- if @council.short_name == 'TCC'
+  = render 'tcc'
+- else
+  = render 'default'
 
-%p
-  Your application for a rates rebate for the 1 July 2018–30 June 2019 rates
-  year has been sent to the Tauranga City Council.
-
-%p
-  %b What you need to do now
-
-%p
-  %ul
-    %li Go to the Tauranga City Council at 91 Willow Street, Tauranga.
-    %li Evidence of income helps to ensure you receive the correct rebate promptly.
-    %li If you are self-employed, you must supply income evidence with your application.
-    %li Tell the Service Centre staff you're there to sign your rates rebate application.
-
-%p
-  %strong
-    Make sure you complete your application by getting your signature witnessed at council
-    offices as soon as you can, as online applications are only open until 31 August 2018.
-    If you do not complete the signature on your application before this date, you will need
-    to complete a paper application form.
-%p
-  Please note: you can only apply for a rebate for the 2018/2019 rates year between
-  1 July 2018 - 20 June 2019.
-
-%p Once your application is completed, your total rebate will be applied to your rates account.
-
-%p
-  %strong
-    If you have any issues, call Tauranga City Council
-    %a{ href: "tel:075777000" } 07 5777 000

--- a/app/views/rebate_forms_mailer/council_mail.html.haml
+++ b/app/views/rebate_forms_mailer/council_mail.html.haml
@@ -1,7 +1,17 @@
 A new rebate application has been sent to you.
 
-%p= @rebate_form.valuation_id
-%p= @rebate_form.fields['address']
-%p= @rebate_form.fields['full_name']
+%p= @rebate_form.full_name
+
+%p
+  %strong valuation id
+  = @rebate_form.valuation_id
+%p
+  = @rebate_form.property.location
+  %br/
+  = @rebate_form.property.suburb
+  %br/
+  = @rebate_form.property.town_city
+  %br/
+
 
 %p= link_to 'Sign this', @rebate_form.signing_url


### PR DESCRIPTION
Auckland can use the default
Tauranga can use their own specific email template

closes https://github.com/ServiceInnovationLab/pancake-frontend/issues/528