### PR TITLE
Auto corrected by following Lint Ruby RSpec/NotToNot

### DIFF
--- a/spec/features/admin/rebate_forms/show_spec.rb
+++ b/spec/features/admin/rebate_forms/show_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'RebateForm', type: :feature do
           it 'goes to the right place' do
             visit "/admin/rebate_forms/#{rebate_form.id}"
             click_link('edit')
-            expect(page).to_not have_text('EDIT')
+            expect(page).not_to have_text('EDIT')
             expect(page).to have_text('Customer details')
             expect(page).to have_text('Signature required')
           end
@@ -74,9 +74,9 @@ RSpec.describe 'RebateForm', type: :feature do
         it 'goes to the right place' do
           visit "/admin/rebate_forms/#{rebate_form.id}/"
           click_link('generate_qr')
-          expect(page).to_not have_text('EDIT')
-          expect(page).to_not have_text('Customer details')
-          expect(page).to_not have_text('Signature required')
+          expect(page).not_to have_text('EDIT')
+          expect(page).not_to have_text('Customer details')
+          expect(page).not_to have_text('Signature required')
         end
       end
 
@@ -84,9 +84,9 @@ RSpec.describe 'RebateForm', type: :feature do
         it 'goes to the right place' do
           visit "/admin/rebate_forms/#{rebate_form.id}/"
           click_link('generate_qr')
-          expect(page).to_not have_text('EDIT')
-          expect(page).to_not have_text('Customer details')
-          expect(page).to_not have_text('Signature required')
+          expect(page).not_to have_text('EDIT')
+          expect(page).not_to have_text('Customer details')
+          expect(page).not_to have_text('Signature required')
         end
       end
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby RSpec/NotToNot

Click [here](https://awesomecode.io/repos/ServiceInnovationLab/pancake-backend/ruby_lint_configs/25944) to configure it on awesomecode.io