### PR TITLE
Removed error handling from Admin::RebateFormsController and RebateFormsService

### DIFF
--- a/app/controllers/admin/rebate_forms_controller.rb
+++ b/app/controllers/admin/rebate_forms_controller.rb
@@ -58,8 +58,6 @@ class Admin::RebateFormsController < Admin::BaseController
     @rebate_form = RebateFormsService.new(rebate_form_fields_params).update!
     @rebate_form.update(updated_by: current_user.id)
     respond_with @rebate_form, location: admin_rebate_form_url(@rebate_form), notice: 'Rebate form was successfully updated.'
-  rescue RebateFormsService::Error
-    redirect_to edit_admin_rebate_form_path(@rebate_form), notice: 'The rebate form did not update, please try again.'
   end
 
   # DELETE /admin/rebate_forms/1

--- a/app/services/rebate_forms_service.rb
+++ b/app/services/rebate_forms_service.rb
@@ -16,8 +16,6 @@ class RebateFormsService
     rebate_form.calc_rebate_amount!
     raise Error if rebate_form.rebate.blank?
     rebate_form
-  rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound
-    raise Error
   end
 
   private

--- a/spec/services/rebate_forms_service_spec.rb
+++ b/spec/services/rebate_forms_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RebateFormsService do
         end
 
         it 'raises an error' do
-          expect { subject.update! }.to raise_error(RebateFormsService::Error)
+          expect { subject.update! }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
 


### PR DESCRIPTION
I removed the error handling from the Controller and the Service to do the first part of handling the bug in the edit action.

@Br3nda on Monday, @mischa-s and I will look into the second part of this, which is fixing up the Javascript to both bull the total rates from the backend and handle errors properly. 

I hope it is ok to do this in two parts!

# How to test this change

- [ ] has tests
- [ ] at least one a reviewer ran the code
