### PR TITLE
Fixing chrome automation in capybara

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,4 @@ script:
 after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t simplecov --id $CC_TEST_REPORTER_ID"
 env:
-- PGPORT=5433
-- YEAR=2019
-- SIGNING_URL="http://127.0.0.1:4000/#/{token}"
-# TODO Update to new open fisca response
-#- OPENFISCA_ORIGN="https://govtnz-rates-rebate-of.herokuapp.com/calculate"
-- OPENFISCA_ORIGIN="https://openfisca.ratesrebates.services.govt.nz/calculate"
-- HMAC_SECRET="DgD3NMLjoEsgbT7bOmpgI0svg18BMHuy0VpE6cX9xMMxznWhvEKIggR61nE/E"
-- APP_URL="http://localhost:3000/"
+- PGPORT=5433 YEAR=2019 SIGNING_URL="http://127.0.0.1:4000/#/{token}" OPENFISCA_ORIGIN="https://openfisca.ratesrebates.services.govt.nz/calculate" HMAC_SECRET="DgD3NMLjoEsgbT7bOmpgI0svg18BMHuy0VpE6cX9xMMxznWhvEKIggR61nE/E" APP_URL="http://localhost:3000/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
-    - google-chrome-stable
     - chromium-chromedriver
 before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
-    - chromium-chromedriver
 before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
 - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
     packages:
     - postgresql-10
     - postgresql-client-10
+    - chromium-chromedriver
+    - google-chrome-stable
 before_install:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64  > ./cc-test-reporter
 - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,11 @@ script:
 after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t simplecov --id $CC_TEST_REPORTER_ID"
 env:
-  global:
-  - PGPORT=5433
-  - YEAR=2019
-  - SIGNING_URL="http://127.0.0.1:4000/#/{token}"
-  # TODO Update to new open fisca response
-  #- OPENFISCA_ORIGN="https://govtnz-rates-rebate-of.herokuapp.com/calculate"
-  - OPENFISCA_ORIGIN="https://openfisca.ratesrebates.services.govt.nz/calculate"
-  - HMAC_SECRET="DgD3NMLjoEsgbT7bOmpgI0svg18BMHuy0VpE6cX9xMMxznWhvEKIggR61nE/E"
-  - APP_URL="http://localhost:3000/"
+- PGPORT=5433
+- YEAR=2019
+- SIGNING_URL="http://127.0.0.1:4000/#/{token}"
+# TODO Update to new open fisca response
+#- OPENFISCA_ORIGN="https://govtnz-rates-rebate-of.herokuapp.com/calculate"
+- OPENFISCA_ORIGIN="https://openfisca.ratesrebates.services.govt.nz/calculate"
+- HMAC_SECRET="DgD3NMLjoEsgbT7bOmpgI0svg18BMHuy0VpE6cX9xMMxznWhvEKIggR61nE/E"
+- APP_URL="http://localhost:3000/"

--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,4 @@ group :test do
   # freezes time in some specs
   gem 'timecop'
   gem 'webdrivers'
-
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  # gem 'chromedriver-helper'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -95,5 +95,5 @@ group :test do
   gem 'webdrivers'
 
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  # gem 'chromedriver-helper'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     aws-eventstream (1.0.3)
@@ -88,9 +86,6 @@ GEM
     chartkick (3.2.0)
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     chunky_png (1.3.11)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -164,7 +159,6 @@ GEM
     image_processing (1.9.0)
       mini_magick (>= 4.9.3, < 5)
       ruby-vips (>= 2.0.13, < 3)
-    io-like (0.3.0)
     jaro_winkler (1.5.2)
     jmespath (1.4.0)
     json (2.2.0)
@@ -431,7 +425,6 @@ DEPENDENCIES
   capybara-screenshot
   capybara-selenium
   chartkick
-  chromedriver-helper
   database_cleaner (~> 1.6)
   devise
   devise_invitable

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,25 +14,10 @@ require 'selenium/webdriver'
 require 'capybara-screenshot/rspec'
 require 'percy'
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
+require 'webdrivers'
 
-Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu] }
-  )
-
-  Capybara::Selenium::Driver.new app,
-                                 browser: :chrome,
-                                 desired_capabilities: capabilities
-end
-
-Capybara::Screenshot.register_driver(:headless_chrome) do |driver, path|
-  driver.browser.save_screenshot(path)
-end
-
-Capybara.javascript_driver = :headless_chrome
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 
 Capybara.raise_server_errors = true
 


### PR DESCRIPTION
chromedriver-helper gem is deprecated. Calling webdriver directly.