### PR TITLE
ensure batched forms cannot be edited

### DIFF
--- a/app/views/admin/rebate_forms/_show_header.html.haml
+++ b/app/views/admin/rebate_forms/_show_header.html.haml
@@ -3,7 +3,7 @@
     =image_tag("search.svg", class: 'rebate-header-icon')
   = link_to admin_rebate_form_path(@rebate_form), id: 'reload' do
     =image_tag("blue-reload.svg", class: 'rebate-header-icon')
-  - unless @rebate_form.processed_state?
+  - unless @rebate_form.processed_state? || @rebate_form.batched_state?
     = link_to 'EDIT', edit_admin_rebate_form_path, id: 'edit', class: 'pure-button rebate-edit'
 
 .rebate-header

--- a/spec/features/admin/rebate_forms/show_spec.rb
+++ b/spec/features/admin/rebate_forms/show_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe 'RebateForm', type: :feature, js: true do
             expect(page).to_not have_text('Processed')
           end
         end
+
+        describe 'when a rebate form is batched' do
+          let!(:batched_rebate_form) { FactoryBot.create(:batched_form) }
+          before { visit "/admin/rebate_forms/#{batched_rebate_form.id}" }
+
+          it 'cannot be edited' do
+            expect(page).to_not have_text('Processed')
+            expect(page).to_not have_text('Unprocess')
+            expect(page).to_not have_text('Edit')
+          end
+        end
         include_examples 'percy snapshot'
       end
 


### PR DESCRIPTION
# What has changed and why?
ensure batched applications can't be edited

# How to test this change
a batched application individual view does not display an edit button
- [x] has tests
- [ ] at least one a reviewer ran the code
