### PR TITLE
Remove year from titles

### DIFF
--- a/app/views/admin/batches/index.html.haml
+++ b/app/views/admin/batches/index.html.haml
@@ -2,7 +2,7 @@
 
 .rebate-wrapper
   %h1.rebate-title
-    Rates Rebate 2018/2019
+    Rates Rebate - The Future and Beyond
   %h2.rebate-subtitle
     Customer search
   = react_component('CustomersSummary', {current_user_roles: current_user.roles, batches: @batches})

--- a/app/views/admin/processed_rebate_forms/index.html.haml
+++ b/app/views/admin/processed_rebate_forms/index.html.haml
@@ -2,7 +2,7 @@
 
 .rebate-wrapper
   %h1.rebate-title
-    Rates Rebate 2018/2019
+    Rates Rebate - The Future and Beyond
   %h2.rebate-subtitle
     Customer search
 

--- a/app/views/admin/rebate_forms/index.html.haml
+++ b/app/views/admin/rebate_forms/index.html.haml
@@ -2,7 +2,7 @@
 
 .rebate-wrapper
   %h1.rebate-title
-    Rates Rebate 2018/2019
+    Rates Rebate - The Future and Beyond
   %h2.rebate-subtitle
     Customer search
 

--- a/app/views/admin/signed_rebate_forms/index.html.haml
+++ b/app/views/admin/signed_rebate_forms/index.html.haml
@@ -2,7 +2,7 @@
 
 .rebate-wrapper
   %h1.rebate-title
-    Rates Rebate 2018/2019
+    Rates Rebate - The Future and Beyond
   %h2.rebate-subtitle
     Customer search
 

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 .login-wrapper
-  %h1.login-title Rates Rebate 2018/2019
+  %h1.login-title Rates Rebate - The Future and Beyond
   %h2.login-subtitle Log in
 
   .login-box

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -1,6 +1,6 @@
 .header-bar
   %div.header-item
-    %strong.header-title Rates Rebate 2018/2019
+    %strong.header-title Rates Rebate - The Future and Beyond
   %div.header-item.header-login
     - if current_user
       - if current_user.name

--- a/spec/features/admin/batches/index_spec.rb
+++ b/spec/features/admin/batches/index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Batch', type: :feature do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin/batches'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/councils/edit_spec.rb
+++ b/spec/features/admin/councils/edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Council', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/councils/#{council.id}"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/councils/index_spec.rb
+++ b/spec/features/admin/councils/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Council', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin/councils'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/councils/new_spec.rb
+++ b/spec/features/admin/councils/new_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Council', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/councils/#{council.id}"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/councils/show_spec.rb
+++ b/spec/features/admin/councils/show_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Council', type: :feature, js: true do
   context 'anonymous' do
     before { visit "/admin/councils/#{council.id}" }
 
-    it { is_expected.to have_text('Rates Rebate 2018/2019') }
+    it { is_expected.to have_text('Rates Rebate - The Future and Beyond') }
     it { is_expected.to have_text('Log in') }
     it { is_expected.not_to have_text(council.name) }
   end

--- a/spec/features/admin/processed_rebate_forms/index_spec.rb
+++ b/spec/features/admin/processed_rebate_forms/index_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'ProcessedRebateForms', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
     include_examples 'percy snapshot'

--- a/spec/features/admin/properties/index_spec.rb
+++ b/spec/features/admin/properties/index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Property', type: :feature do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/councils/#{council.id}/properties"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/rebate_forms/edit_spec.rb
+++ b/spec/features/admin/rebate_forms/edit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'RebateForm', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/rebate_forms/#{rebate_form.id}"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/rebate_forms/index_spec.rb
+++ b/spec/features/admin/rebate_forms/index_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'RebateForm', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
     include_examples 'percy snapshot'

--- a/spec/features/admin/rebate_forms/show_spec.rb
+++ b/spec/features/admin/rebate_forms/show_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'RebateForm', type: :feature, js: true do
 
   it "Anonymous can't see it" do
     visit "/admin/rebate_forms/#{rebate_form.id}"
-    expect(page).to have_text('Rates Rebate 2018/2019')
+    expect(page).to have_text('Rates Rebate - The Future and Beyond')
     expect(page).to have_text('Log in')
     expect(page).not_to have_text('Log out x')
   end
@@ -55,7 +55,7 @@ RSpec.describe 'RebateForm', type: :feature, js: true do
               visit "/admin/rebate_forms/#{rebate_form.id}"
               click_link('back')
             end
-            it { expect(page).to have_text('Rates Rebate 2018/2019') }
+            it { expect(page).to have_text('Rates Rebate - The Future and Beyond') }
           end
         end
 

--- a/spec/features/admin/rebate_forms_council_details/edit_spec.rb
+++ b/spec/features/admin/rebate_forms_council_details/edit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'RebateFormsCouncilDetails', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/rebate_forms/edit_council_details?rebate_form_id=#{rebate_form.id}"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/users/edit_spec.rb
+++ b/spec/features/admin/users/edit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'User', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit "/admin/users/#{user1.id}"
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'User', type: :feature, js: true do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin/users'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
     end
   end

--- a/spec/features/logins.rb
+++ b/spec/features/logins.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Logging in', type: :feature do
   context 'anonymous' do
     it "can't see it" do
       visit '/admin'
-      expect(page).to have_text('Rates Rebate 2018/2019')
+      expect(page).to have_text('Rates Rebate - The Future and Beyond')
       expect(page).to have_text('Log in')
       expect(page).not_to have_text('Log out')
     end


### PR DESCRIPTION
# What has changed and why?
We're now serving rebates for the 2019 to 2010 rating year - so instead of hard coding years into titles, let's use a catchy catch phrase.

# How to test this change
View some pages, see the title

- [ ] has tests
- [ ] at least one a reviewer ran the code
